### PR TITLE
Fixes #6. GCC 8 on discover requires pthread

### DIFF
--- a/UMD_oletkf/CMakeLists.txt
+++ b/UMD_oletkf/CMakeLists.txt
@@ -28,17 +28,17 @@ target_compile_definitions (${this} PUBLIC _LAPACK_ gmao_intf HAVE_ESMF)
 ecbuild_add_executable (
    TARGET oceanda.x 
    SOURCES letkf.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
    )
 
 ecbuild_add_executable (
    TARGET oceanobsop.x 
    SOURCES obsop.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
    )
 
 ecbuild_add_executable (
    TARGET oceanobs_nc2bin.x 
    SOURCES oceanobs_nc2bin.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
    )

--- a/UMD_utils/CMakeLists.txt
+++ b/UMD_utils/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach (file ocean_recenter anaice2rst ocean_moments ocean_iau)
    ecbuild_add_executable (
       TARGET ${file}.x 
       SOURCES ${file}.f90 
-      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
       )
 endforeach ()
 

--- a/UMD_utils/sosie-2.6.4/CMakeLists.txt
+++ b/UMD_utils/sosie-2.6.4/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach (file sosie corr_vect interp_to_line mask_drown_field)
    ecbuild_add_executable (
       TARGET ${file}.x 
       SOURCES src/${file}.f90 
-      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
       )
 endforeach ()
 


### PR DESCRIPTION
This seems to be something only on discover probably because other GCC MPI stacks I've built must include pthread? Anyway, I believe `GEOSgcm.x` is fine because `GMAO_mpeu` seems to have `Threads::Threads` in its `CMakeLists.txt` file and that is inherited.

This should be fairly safe as we seem to build with `-lpthread` with Intel all over.