### PR TITLE
Fixes #9. Remove C-like comment fragments

### DIFF
--- a/UMD_utils/anaice2rst.f90
+++ b/UMD_utils/anaice2rst.f90
@@ -1,6 +1,6 @@
 program anaice2rst 
 !!$ /////////////////////////////////////////////////////////////////////////
-!!$ /**
+!!$ *
 !!$ * Title: anaice2rst.f90
 !!$ *
 !!$ * Description: Based on Bin Zhao's code that converts PIOMASS 12 itd into CICE 5 itd. 

--- a/UMD_utils/check_temp_salt.f90
+++ b/UMD_utils/check_temp_salt.f90
@@ -1,6 +1,6 @@
 program check_temp_salt
 !!$ /////////////////////////////////////////////////////////////////////////
-!!$ /**
+!!$ *
 !!$ * Title: check_temp_salt.f90
 !!$ *
 !!$ * Description: Filter out un-physical values

--- a/UMD_utils/ocean_iau.f90
+++ b/UMD_utils/ocean_iau.f90
@@ -1,6 +1,6 @@
 program mk_iau_increments
 !!$ /////////////////////////////////////////////////////////////////////////
-!!$ /**
+!!$ *
 !!$ * Title: mk_iau_incr
 !!$ * ARGUMENT:
 !!$ *        -DO_ANA_INCR                     : compute iau increment and sst relaxation

--- a/UMD_utils/ocean_moments.f90
+++ b/UMD_utils/ocean_moments.f90
@@ -1,6 +1,6 @@
 program moments
 !!$ /////////////////////////////////////////////////////////////////////////
-!!$ /**
+!!$ *
 !!$ * Title: ocean_moments.f90
 !!$ *
 !!$ * Description: Computes first and second moments of the background and analysis. Filter out un-physical values. Impose minmax limits


### PR DESCRIPTION
For some reason the Ninja build system is trying to interpret the `/**`
as the start of a comment with no end and dies.

So, since it's just part of Fortran comment, make it less likely to
trigger.