### PR TITLE
Fixes for CMake using F2Py and LaTeX

### DIFF
--- a/UMD_utils/CMakeLists.txt
+++ b/UMD_utils/CMakeLists.txt
@@ -26,14 +26,14 @@ foreach (file ocean_recenter anaice2rst ocean_moments ocean_iau)
       )
 endforeach ()
 
-include(UseF2Py)
-
-add_f2py_module(read_merra2_bcs
-   SOURCES read_bin.f90
-   DESTINATION bin
-   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
-   )
-add_dependencies(read_merra2_bcs ${this})
+if (F2PY_FOUND)
+   add_f2py_module(read_merra2_bcs
+      SOURCES read_bin.f90
+      DESTINATION bin
+      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
+      )
+   add_dependencies(read_merra2_bcs ${this})
+endif (F2PY_FOUND)
 
 file (GLOB python_files *.py)
 install(


### PR DESCRIPTION
This update fixes some issues where systems do not have
either ImageMagick or F2Py. If F2Py is not found, then F2Py
targets are not built.

This should be taken in concert with:

GEOS-ESM/ESMA_cmake#62
GEOS-ESM/GEOSchem_GridComp#68
GEOS-ESM/GMAO_Shared#84
GEOS-ESM/UMD_Etc#11

That said, if the ESMA_cmake PR/change is not taken, the model will still build, but no f2py will run (as it's missing the `F2PY_FOUND` variable).