### PR TITLE
Make Ocean Team own all files (save CMake)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+# Everything in GEOSgcm_GridComp should be owned by the GCM Gatekeepers
+* @GEOS-ESM/ocean-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 


### PR DESCRIPTION
This PR should make @GEOS-ESM/ocean-team the codeowner of all the files in UMD_Etc.