### PR TITLE
Updates to use Python2 and Python3 at same time

### DIFF
--- a/UMD_utils/CMakeLists.txt
+++ b/UMD_utils/CMakeLists.txt
@@ -26,14 +26,15 @@ foreach (file ocean_recenter anaice2rst ocean_moments ocean_iau)
       )
 endforeach ()
 
-if (F2PY_FOUND)
-   add_f2py_module(read_merra2_bcs
+if (USE_F2PY)
+   find_package(F2PY2)
+   esma_add_f2py2_module(read_merra2_bcs
       SOURCES read_bin.f90
       DESTINATION bin
       INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
       )
    add_dependencies(read_merra2_bcs ${this})
-endif (F2PY_FOUND)
+endif ()
 
 file (GLOB python_files *.py)
 install(

--- a/UMD_utils/CMakeLists.txt
+++ b/UMD_utils/CMakeLists.txt
@@ -28,12 +28,14 @@ endforeach ()
 
 if (USE_F2PY)
    find_package(F2PY2)
-   esma_add_f2py2_module(read_merra2_bcs
-      SOURCES read_bin.f90
-      DESTINATION bin
-      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
-      )
-   add_dependencies(read_merra2_bcs ${this})
+   if (F2PY2_FOUND)
+      esma_add_f2py2_module(read_merra2_bcs
+         SOURCES read_bin.f90
+         DESTINATION bin
+         INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
+         )
+      add_dependencies(read_merra2_bcs ${this})
+   endif ()
 endif ()
 
 file (GLOB python_files *.py)


### PR DESCRIPTION
NOTE: Requires ESMA_cmake v3.4.0 to fully work (see https://github.com/GEOS-ESM/ESMA_cmake/pull/159)