### PR TITLE
Updates to support Spack

### DIFF
--- a/UMD_oletkf/CMakeLists.txt
+++ b/UMD_oletkf/CMakeLists.txt
@@ -2,11 +2,11 @@ esma_set_this ()
 
 
 set (SRCS
-   common.f90 common_mpi.f90 common_mtx.f90 mod_sfmt.f90 
+   common.f90 common_mpi.f90 common_mtx.f90 mod_sfmt.f90
    params_letkf.f90 params_model.f90 params_obs.f90 vars_model.f90
    vars_obs.f90 common_letkf.f90 common_mom4.f90 common_mpi_mom4.f90
    common_obs_mom4.f90 letkf_obs.f90 letkf_local.f90
-   letkf_tools.f90 gsw_pot_to_insitu.f90 netlib2.f 
+   letkf_tools.f90 gsw_pot_to_insitu.f90 netlib2.f
   )
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
@@ -19,26 +19,25 @@ set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_RELEASE}")
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  INCLUDES ${INC_NETCDF}
-  DEPENDENCIES ${NETCDF_LIBRARIES} mom6 ${MPI_Fortran_LIBRARIES}
+  DEPENDENCIES mom6 NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   )
 
 target_compile_definitions (${this} PUBLIC _LAPACK_ gmao_intf HAVE_ESMF)
 
 ecbuild_add_executable (
-   TARGET oceanda.x 
-   SOURCES letkf.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
+   TARGET oceanda.x
+   SOURCES letkf.f90
+   LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads
    )
 
 ecbuild_add_executable (
-   TARGET oceanobsop.x 
-   SOURCES obsop.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
+   TARGET oceanobsop.x
+   SOURCES obsop.f90
+   LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads
    )
 
 ecbuild_add_executable (
-   TARGET oceanobs_nc2bin.x 
-   SOURCES oceanobs_nc2bin.f90 
-   LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
+   TARGET oceanobs_nc2bin.x
+   SOURCES oceanobs_nc2bin.f90
+   LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads
    )

--- a/UMD_utils/CMakeLists.txt
+++ b/UMD_utils/CMakeLists.txt
@@ -12,17 +12,16 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  INCLUDES ${INC_NETCDF}
-  DEPENDENCIES ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+  DEPENDENCIES NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   )
 
 target_compile_definitions (${this} PUBLIC _LAPACK_ gmao_intf HAVE_ESMF)
 
 foreach (file ocean_recenter anaice2rst ocean_moments ocean_iau)
    ecbuild_add_executable (
-      TARGET ${file}.x 
-      SOURCES ${file}.f90 
-      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
+      TARGET ${file}.x
+      SOURCES ${file}.f90
+      LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads
       )
 endforeach ()
 

--- a/UMD_utils/sosie-2.6.4/CMakeLists.txt
+++ b/UMD_utils/sosie-2.6.4/CMakeLists.txt
@@ -20,17 +20,16 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  INCLUDES ${INC_NETCDF}
-  DEPENDENCIES ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES}
+  DEPENDENCIES NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   )
 
 target_compile_definitions (${this} PUBLIC _LAPACK_ gmao_intf HAVE_ESMF)
 
 foreach (file sosie corr_vect interp_to_line mask_drown_field)
    ecbuild_add_executable (
-      TARGET ${file}.x 
-      SOURCES src/${file}.f90 
-      LIBS ${this} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} Threads::Threads
+      TARGET ${file}.x
+      SOURCES src/${file}.f90
+      LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads
       )
 endforeach ()
 


### PR DESCRIPTION
This zero-diff PR has build system changes to support the use of Spack. Most of the changes just make the GEOS CMake look more like canonical CMake. GEOS previously couldn't support this, but it now can.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for overall issue.