### PR TITLE
update legacy bcs path

### DIFF
--- a/UMD_rc/gcm_run.j
+++ b/UMD_rc/gcm_run.j
@@ -169,7 +169,7 @@ done:
 #                        Link Boundary Datasets
 #######################################################################
 
-setenv BCSDIR    /discover/nobackup/ltakacs/bcs/Ganymed-4_0/Ganymed-4_0_Reynolds
+setenv BCSDIR    /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/bcs/Ganymed-4_0/Ganymed-4_0_Reynolds
 setenv CHMDIR    /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3
 setenv BCRSLV    ${ATMOStag}_DE0360xPE0180
 setenv DATELINE  DC

--- a/UMD_rc/setup_reinit.j
+++ b/UMD_rc/setup_reinit.j
@@ -182,7 +182,7 @@ chmod +x $FILE
 #                        Link Boundary Datasets
 #######################################################################
 
-setenv BCSDIR    /discover/nobackup/ltakacs/bcs/Ganymed-4_0/Ganymed-4_0_Reynolds
+setenv BCSDIR    /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/bcs/Ganymed-4_0/Ganymed-4_0_Reynolds
 setenv CHMDIR    /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3
 setenv BCRSLV    ${ATMOStag}_DE0360xPE0180
 setenv DATELINE  DC


### PR DESCRIPTION
This PR updates the path to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space on Discover (replacing /discover/nobackup/ltakacs/bcs/ )

This is the first step in using (legacy) bcs from the new "bcs_shared" dir.

This PR is one of a group of similar PRs:
- GEOSgcm_GridComp: https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/718
- GEOSgcm_App: https://github.com/GEOS-ESM/GEOSgcm_App/pull/401
- GEOS_Util: https://github.com/GEOS-ESM/GEOS_Util/pull/10
- GOCART: https://github.com/GEOS-ESM/GOCART/pull/212
- UMD_ETc: https://github.com/GEOS-ESM/UMD_Etc/pull/21

cc:  @gmao-rreichle 